### PR TITLE
fix

### DIFF
--- a/modules/lighting.js
+++ b/modules/lighting.js
@@ -159,12 +159,12 @@ export const setupLighting = (scene, paintings) => {
   statueSpotlight.penumbra = 1;
   statueSpotlight.distance = 0;
 
-  // const statueSpotlightFolder = gui.addFolder("Statue Light");
-  // statueSpotlightFolder.add(statueSpotlight, "intensity", 0, 4);
-  // statueSpotlightFolder
-  //   .add(statueSpotlight, "angle", 0, Math.PI / 2)
-  //   .name("Angle");
-  // statueSpotlightFolder.add(statueSpotlight, "penumbra", 0, 1).name("Penumbra");
-  // statueSpotlightFolder.add(statueSpotlight, "decay", 0, 2).name("Decay");
-  // statueSpotlightFolder.close();
+  const statueSpotlightFolder = gui.addFolder("Statue Light");
+  statueSpotlightFolder.add(statueSpotlight, "intensity", 0, 4);
+  statueSpotlightFolder
+    .add(statueSpotlight, "angle", 0, Math.PI / 2)
+    .name("Angle");
+  statueSpotlightFolder.add(statueSpotlight, "penumbra", 0, 1).name("Penumbra");
+  statueSpotlightFolder.add(statueSpotlight, "decay", 0, 2).name("Decay");
+  statueSpotlightFolder.close();
 };

--- a/modules/statue.js
+++ b/modules/statue.js
@@ -69,22 +69,13 @@ export const loadStatueModel = (scene, renderer, camera, onLoaded) => {
       };
 
       // Modify the animate function to include distance check
-      const animate = () => {
-        requestAnimationFrame(animate);
-
-        // Rotate the statue around the Y-axis
+      // 1) Xoá toàn bộ animate() + requestAnimationFrame + render ở đây
+      // 2) Đăng ký callback quay tượng cho main loop:
+      statue.userData.animate = () => {
         statue.rotation.y += 0.01;
-        checkDistance(); // Check distance in each frame
-
-        // Ensure renderer, scene, and camera are defined before rendering
-        if (renderer && scene && camera) {
-          renderer.render(scene, camera);
-        } else {
-          console.error("Renderer, scene, or camera is not defined.");
-        }
+        checkDistance();
       };
 
-      animate(); // Start the animation loop
     },
     undefined,
     (error) => {


### PR DESCRIPTION
## Summary by Sourcery

Refactor statue animation to be driven by the main loop and restore GUI controls for statue lighting

Enhancements:
- Remove internal animate loop in loadStatueModel and register statue.userData.animate callback for external rendering
- Re-enable and configure the GUI folder for statueSpotlight parameters in setupLighting to allow live tuning